### PR TITLE
Add S3 Arn as output

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Create the bucket and the user in a single go.
 ### Output
  * [`access_key`]: String: The AWS access key for the created backup user
  * [`secret_name`]: String: The name of the ELB
+ * [`arn`]: String: The ARN of the S3 bucket to hold the backups.
 
 ### Example
   ```

--- a/duply-bucket-iamuser/outputs.tf
+++ b/duply-bucket-iamuser/outputs.tf
@@ -5,3 +5,7 @@ output "access_key" {
 output "secret_key" {
   value = "${module.user.secret_key}"
 }
+
+output "arn" {
+  value = "${module.bucket.arn}"
+}


### PR DESCRIPTION
Add the S3 Arn as output so this can be used in other parts of terraform. A practical example is to use the S3 arn for IAM policies. 